### PR TITLE
(failed 'master' builds) retry promotion up to 8 times or every 15m for 2 hours

### DIFF
--- a/packs/python-microservice/Jenkinsfile
+++ b/packs/python-microservice/Jenkinsfile
@@ -140,8 +140,11 @@ pipeline {
               sh "jx step changelog --version v$VERSION"
               // release the helm chart
               sh 'make release'
-              // promote through all 'Auto' promotion Environments
-              sh "jx promote -b --all-auto --timeout 1h --version $VERSION"
+              /** retry 8 times, or every 15 minutes for 2 hours */
+              retry(8) {
+                // promote through all 'Auto' promotion Environments
+                sh "jx promote -b --all-auto --timeout 15m --version $VERSION"
+              }
             }
           }
         }

--- a/packs/python-model-microservice/Jenkinsfile
+++ b/packs/python-model-microservice/Jenkinsfile
@@ -140,8 +140,11 @@ pipeline {
               sh "jx step changelog --version v$VERSION"
               // release the helm chart
               sh 'make release'
-              // promote through all 'Auto' promotion Environments
-              sh "jx promote -b --all-auto --timeout 1h --version $VERSION"
+              /** retry 8 times, or every 15 minutes for 2 hours */
+              retry(8) {
+                // promote through all 'Auto' promotion Environments
+                sh "jx promote -b --all-auto --timeout 15m --version $VERSION"
+              }
             }
           }
         }


### PR DESCRIPTION
i don't think this is a perfect solution to: 
> multiple prs getting merged ahead of another build for a build to pass it's 'master' build without increasing the version number

other ideas:
- maybe jx should be catching it? 
- or environments should change to build every commit?