### PR TITLE
add microservice_name to custom packs' deployment.yaml

### DIFF
--- a/packs/python-microservice/charts/templates/deployment.yaml
+++ b/packs/python-microservice/charts/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        microservice_name: {{ .Values.service.name }}
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
 {{- if .Values.podAnnotations }}

--- a/packs/python-model-microservice/charts/templates/deployment.yaml
+++ b/packs/python-model-microservice/charts/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        microservice_name: {{ .Values.service.name }}
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
 {{- if .Values.podAnnotations }}


### PR DESCRIPTION
Like the title says. This will obviate having our logger putting microservice_name in each entry. The plan is to add this to all our existing k8s deployments too.