### PR TITLE
add ".dev" to comply with PEP 440

### DIFF
--- a/packs/python-library/Jenkinsfile
+++ b/packs/python-library/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
             base_version = sh(script: "pipenv run python setup.py --version", returnStdout: true).trim()
             pr = BRANCH_NAME.replaceAll(/-/, "").toLowerCase()
-            expanded_version = "${base_version}+${pr}.${BUILD_NUMBER}"
+            expanded_version = "${base_version}.dev+${pr}.${BUILD_NUMBER}"
 
             sh "sed -i -e 's/^__version__ = .*/__version__ = \"$expanded_version\"/' setup.py"
 


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0440/#developmental-releases states that developmental releases require the ".devN" postfix. We've only been adding local version segments to include PR and build numbers.

Artifactory treats releases like "package+pr-6.3" as final releases, so adding ".devN" should allow it to serve dev releases properly.

Resolves https://github.com/arturo-ai/infra/issues/67