### PR TITLE
better accommodate pep440

### DIFF
--- a/packs/python-library/Jenkinsfile
+++ b/packs/python-library/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
             base_version = sh(script: "pipenv run python setup.py --version", returnStdout: true).trim()
             pr = BRANCH_NAME.replaceAll(/-/, "").toLowerCase()
-            expanded_version = "${base_version}.dev+${pr}.${BUILD_NUMBER}"
+            expanded_version = "${base_version}.dev0+${pr}.${BUILD_NUMBER}"
 
             sh "sed -i -e 's/^__version__ = .*/__version__ = \"$expanded_version\"/' setup.py"
 


### PR DESCRIPTION
Though adding a number to the ".dev" postfix is optional while publishing a package version, Artifactory (and probably any other package index) will add "0" to "dev" if no number is provided. For example, `0.312.0.dev` is valid but will be changed to `0.312.0.dev0` in the package index.

Added "0" to make sure the advertised version matches what's actually in Artifactory. (We could come up with a number that more semantically relates to PR and build numbers. Open to suggestions.)